### PR TITLE
HTTPUtils minor fixes / improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = org.threadly
-version = 0.11
+version = 0.12
 threadlyVersion = 5.3
 litesocketsVersion = 4.1
 org.gradle.parallel=true

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/shared/HTTPUtils.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/shared/HTTPUtils.java
@@ -24,12 +24,6 @@ public class HTTPUtils {
     return value.substring(count);
   }
   
-  public static String bbToString(ByteBuffer bb) {
-    byte[] ba = new byte[bb.remaining()];
-    bb.get(ba);
-    return new String(ba);
-  }
-  
   public static int getNextChunkLength(final ByteBuffer bb) {
     MergedByteBuffers mbb = new ReuseableMergedByteBuffers();
     mbb.add(bb);
@@ -57,30 +51,25 @@ public class HTTPUtils {
     return newBB;
   }
   
-  public static byte[] wrapInChunk(byte[] ba) {
-    return wrapInChunk(ByteBuffer.wrap(ba)).array();
-  }
-  
   public static String queryToString(Map<String,String> map) {
-    if(map.size() > 0) {
-      StringBuilder sb = new StringBuilder();
-      sb.append("?");
-      int count = 0;
-      for(String k: map.keySet()) {
-        if(count > 0) {
-          sb.append("&");  
-        }
-        sb.append(k);
-        String v = map.get(k);
-        if(v != null && ! v.equals("")) {
-          sb.append("=");
-          sb.append(v);
-        }
-        count++;
-      }
-      return sb.toString();
+    if(map.isEmpty()) {
+      return "";
     }
-    return "";
+    
+    StringBuilder sb = new StringBuilder();
+    sb.append('?');
+    for(String k: map.keySet()) {
+      if(sb.length() > 1) {
+        sb.append('&');  
+      }
+      sb.append(k);
+      String v = map.get(k);
+      if(! StringUtils.isNullOrEmpty(v)) {
+        sb.append('=');
+        sb.append(v);
+      }
+    }
+    return sb.toString();
   }
   
   public static Map<String, String> queryToMap(String query) {
@@ -94,6 +83,10 @@ public class HTTPUtils {
     String[] tmpQ = query.trim().split("&");
     for(String kv: tmpQ) {
       String[] tmpkv = kv.split("=");
+      if (tmpkv.length == 0) {
+        // case where either no `=` or empty key string
+        continue;
+      }
       if(tmpkv.length == 1) {
         map.put(tmpkv[0].trim(), "");
       } else {

--- a/protocol/src/test/java/org/threadly/litesockets/protocols/http/RequestTests.java
+++ b/protocol/src/test/java/org/threadly/litesockets/protocols/http/RequestTests.java
@@ -150,7 +150,7 @@ public class RequestTests {
     hrp.processData(DATA_BA);
     assertTrue(cb.finished);
     assertEquals(1, cb.bbs.size());
-    assertEquals(DATA, HTTPUtils.bbToString(cb.bbs.get(0).duplicate()));
+    assertEquals(DATA, bbToString(cb.bbs.get(0).duplicate()));
     System.out.println("-----\n"+hr.toString()+"-----");
     System.out.println("-----\n"+cb.request.toString()+"-----");
     assertEquals(hr.toString(), cb.request.toString());
@@ -226,7 +226,7 @@ public class RequestTests {
     hrp.processData(hr.getByteBuffer());
     assertEquals(hr, cb.request);
     assertEquals(hr.toString(), cb.request.toString());
-    byte[] ba = HTTPUtils.wrapInChunk(DATA_BA);
+    byte[] ba = wrapInChunk(DATA_BA);
     for(int i = 0; i<ba.length; i++) {
       byte[] nba = new byte[1];
       nba[0] = ba[i];
@@ -252,13 +252,13 @@ public class RequestTests {
     assertEquals("/test12334", cb.request.getHTTPRequestHeaders().getRequestPath());
     assertEquals(HTTPRequestType.GET.toString(), cb.request.getHTTPRequestHeaders().getRequestType());
     assertEquals("1", cb.request.getHTTPRequestHeaders().getRequestQuery().get("query"));
-    hrp.processData(HTTPUtils.wrapInChunk(DATA_BA));
+    hrp.processData(wrapInChunk(DATA_BA));
     assertEquals(1, cb.bbs.size());
-    assertEquals(DATA, HTTPUtils.bbToString(cb.bbs.get(0).duplicate()));
-    hrp.processData(HTTPUtils.wrapInChunk(DATA_BA));
+    assertEquals(DATA, bbToString(cb.bbs.get(0).duplicate()));
+    hrp.processData(wrapInChunk(DATA_BA));
     assertFalse(cb.finished);
     assertEquals(2, cb.bbs.size());
-    assertEquals(DATA, HTTPUtils.bbToString(cb.bbs.get(1).duplicate()));
+    assertEquals(DATA, bbToString(cb.bbs.get(1).duplicate()));
     hrp.processData(HTTPUtils.wrapInChunk(ByteBuffer.allocate(0)));
     
     assertTrue(cb.finished);
@@ -283,8 +283,18 @@ public class RequestTests {
     assertEquals(10, cb.finishedHeadersCalls);
     assertEquals(10, cb.bbs.size());
     for(ByteBuffer bb2: cb.bbs) {
-      assertEquals(DATA, HTTPUtils.bbToString(bb2));
+      assertEquals(DATA, bbToString(bb2));
     }
+  }
+  
+  private static String bbToString(ByteBuffer bb) {
+    byte[] ba = new byte[bb.remaining()];
+    bb.get(ba);
+    return new String(ba);
+  }
+  
+  private static byte[] wrapInChunk(byte[] ba) {
+    return HTTPUtils.wrapInChunk(ByteBuffer.wrap(ba)).array();
   }
   
   public static class HTTPCB implements HTTPRequestCallback {


### PR DESCRIPTION
Primary fix is that in `queryToMap` we would throw an ArrayOutOfBoundsException if `&=` is provided.  We now will just skip this condition.
While there, I noticed there was two functions which seemed to have limited value and were not used anywhere outside of unit tests I could find (so I moved them to unit tests since their external value seemed limited).
Looking at `queryToString` I also did some minor optimizations.

@lwahlmeier any objections with any of this?