### PR TITLE
HTTPClient timeout debugging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.threadly
 version = 0.21-SNAPSHOT
-threadlyVersion = 5.30
+threadlyVersion = 5.31
 litesocketsVersion = 4.9
 org.gradle.parallel=false
 junitVersion = 4.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group = org.threadly
 version = 0.21-SNAPSHOT
-threadlyVersion = 5.29
-litesocketsVersion = 4.8
+threadlyVersion = 5.30
+litesocketsVersion = 4.9
 org.gradle.parallel=false
 junitVersion = 4.12
 

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestBuilder.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestBuilder.java
@@ -288,6 +288,8 @@ public class HTTPRequestBuilder {
     }
     hrb.setHost(host);
     hrb.setPort(port);
+    hrb.setSSL(doSSL);
+    hrb.setTimeout(timeoutMS, TimeUnit.MILLISECONDS);
     return hrb;
   }
 


### PR DESCRIPTION
This tracks the state of the client request.  If the request is canceled (likely through the watchdog / timeout, but possibly externally by the user as well), then state at point of being canceled will be reported in the message of the `CancellationException`.  This uses some recently added threadly features to gain this visibility.

@lwahlmeier Let me know your thoughts here, I think being able to improve debugging would be very helpful to me.  Ideally I would like to get this released this week if we agree this is an improvement 