### PR TITLE
HttpClient: Allow queue limit and change request exceptions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = org.threadly
-version = 0.23
+version = 0.24-SNAPSHOT
 threadlyVersion = 5.37
 litesocketsVersion = 4.10
 org.gradle.parallel=false


### PR DESCRIPTION
This commit includes two changes:
1) Allows you to set a queue limit for requests

It's still recommended the queue size to be at least as large as the number of concurrent requests due to the fact that all requests must pass through the queue.

This limit however can alleviate conditions where we otherwise would need to timeout by being in queue so long.  Instead we can now fail fast when the client is not making progress

2) This changes the exceptions which may be thrown from `request` to no longer only be `HTTPParsingException`

This is to make the behavior uniform with asyncRequest.  AsyncRequest may throw a `CancellationException`, a `RejectedExecutionException`, or other cases which are not only `HTTPParsingException`.  Rather than changing the async request to always return this exception, I think it's better to let the specific exception types bubble up.  Alternatively we could create `http` exceptions for each condition we want to report, however I don't believe it's worth the per-request overhead to map these exception types.

@lwahlmeier Let me know your thoughts, thanks!