### PR TITLE
Streaming http client improvements

### DIFF
--- a/client/src/main/java/org/threadly/litesockets/client/http/HTTPClient.java
+++ b/client/src/main/java/org/threadly/litesockets/client/http/HTTPClient.java
@@ -370,9 +370,11 @@ public class HTTPClient extends AbstractService {
 
   protected void processQueue() {
     //This should be done after we do a .select on the ntse to check for more jobs before it exits.
-    HTTPRequestWrapper hrw;
-    while(maxConcurrent > inProcess.size() && (hrw = queue.poll()) != null) {
-      process(hrw);
+    synchronized (inProcess) {
+      HTTPRequestWrapper hrw;
+      while(maxConcurrent > inProcess.size() && (hrw = queue.poll()) != null) {
+        process(hrw);
+      }
     }
   }
   

--- a/client/src/main/java/org/threadly/litesockets/client/http/HTTPClient.java
+++ b/client/src/main/java/org/threadly/litesockets/client/http/HTTPClient.java
@@ -393,13 +393,12 @@ public class HTTPClient extends AbstractService {
         addBackTCPClient(hrw.chr.getHTTPAddress(), freshClient); // if client is cleaned up this will ignore
         return;
       }
-      SimpleMergedByteBuffers writeBuffer;
+      MergedByteBuffers writeBuffer;
       if (hrw.chr.getBodyBuffer() == null) {
-        writeBuffer = new SimpleMergedByteBuffers(false, 
-                                                  hrw.chr.getHTTPRequest().getByteBuffer());
+        writeBuffer = hrw.chr.getHTTPRequest().getMergedByteBuffers();
       } else {
         writeBuffer = new SimpleMergedByteBuffers(false, 
-                                                  hrw.chr.getHTTPRequest().getByteBuffer(), 
+                                                  hrw.chr.getHTTPRequest().getMergedByteBuffers(), 
                                                   hrw.chr.getBodyBuffer().duplicate());
       }
       hrw.client.write(writeBuffer);

--- a/client/src/main/java/org/threadly/litesockets/client/http/HTTPStreamClient.java
+++ b/client/src/main/java/org/threadly/litesockets/client/http/HTTPStreamClient.java
@@ -175,8 +175,7 @@ public class HTTPStreamClient implements StreamingClient {
   public ListenableFuture<?> write(ByteBuffer bb) {
     if(currentHttpRequest == null) {
       throw new IllegalStateException("Must have a pending HTTPRequest before you can write!");
-    }
-    if(currentHttpRequest != null && currentHttpRequest.getHTTPHeaders().isChunked()) {
+    } else if(currentHttpRequest.getHTTPHeaders().isChunked()) {
       return client.write(HTTPUtils.wrapInChunk(bb));
     } else {
       return client.write(bb);

--- a/client/src/main/java/org/threadly/litesockets/client/http/HTTPStreamClient.java
+++ b/client/src/main/java/org/threadly/litesockets/client/http/HTTPStreamClient.java
@@ -143,9 +143,9 @@ public class HTTPStreamClient implements StreamingClient {
   public void setRequestResponseHeaders(HTTPRequest httpRequest, HTTPResponse httpResponse, boolean writeResponse) {
     if(!slfResponse.isDone()) {
       currentHttpRequest = httpRequest;
-      httpProcessor.processData(httpResponse.getByteBuffer());
+      httpProcessor.processData(httpResponse.getMergedByteBuffers());
       if(writeResponse) {
-        client.write(httpResponse.getByteBuffer());
+        client.write(httpResponse.getMergedByteBuffers());
       }
     }
   }
@@ -167,7 +167,7 @@ public class HTTPStreamClient implements StreamingClient {
     }
     currentHttpRequest = request;
     slfResponse = new SettableListenableFuture<HTTPResponse>(false);
-    client.write(request.getByteBuffer());
+    client.write(request.getMergedByteBuffers());
     return slfResponse;
   }
   

--- a/client/src/test/java/org/threadly/litesockets/client/http/FakeHTTPStreamingServer.java
+++ b/client/src/test/java/org/threadly/litesockets/client/http/FakeHTTPStreamingServer.java
@@ -87,7 +87,7 @@ public class FakeHTTPStreamingServer  {
 
       @Override
       public void headersFinished(HTTPRequest hreq) {
-        c.write(hr.getByteBuffer());
+        c.write(hr.getMergedByteBuffers());
         sendBack.begin();
         sendBack.begin();
         while(sendBack.remaining() > 0) {

--- a/client/src/test/java/org/threadly/litesockets/client/http/TestHTTPServer.java
+++ b/client/src/test/java/org/threadly/litesockets/client/http/TestHTTPServer.java
@@ -84,7 +84,7 @@ public class TestHTTPServer {
 
       @Override
       public void headersFinished(HTTPRequest hreq) {
-        ListenableFuture<?> lf = c.write(hr.getByteBuffer());
+        ListenableFuture<?> lf = c.write(hr.getMergedByteBuffers());
         sendBack.begin();
         
         while(sendBack.remaining() > 0) {

--- a/client/src/test/java/org/threadly/litesockets/client/websocket/WebSocketClientTest.java
+++ b/client/src/test/java/org/threadly/litesockets/client/websocket/WebSocketClientTest.java
@@ -125,7 +125,7 @@ public class WebSocketClientTest {
       slf.setResult(c.getRead());
     });
     WSclient.connect().get(10, TimeUnit.SECONDS);
-    WSclient.write(WSClient.DEFAULT_WS_REQUEST.getByteBuffer());
+    WSclient.write(WSClient.DEFAULT_WS_REQUEST.getMergedByteBuffers());
     slf.get(10, TimeUnit.SECONDS);
     
     final WSClient wsc = new WSClient(WSclient);
@@ -267,7 +267,7 @@ public class WebSocketClientTest {
           HTTPResponseBuilder hrb = new HTTPResponseBuilder().setResponseHeader(new HTTPResponseHeader(HTTPResponseCode.NotFound, HTTPConstants.HTTP_VERSION_1_1));
           hrb.setHeader(HTTPConstants.HTTP_KEY_WEBSOCKET_ACCEPT, respKey);
           hrb.setHeader(HTTPConstants.HTTP_KEY_CONTENT_LENGTH, null);
-          client.write(hrb.build().getByteBuffer());
+          client.write(hrb.build().getMergedByteBuffers());
           if(mbb.remaining() > 0) {
             client.write(mbb.pullBuffer(mbb.remaining()));
           }
@@ -299,7 +299,7 @@ public class WebSocketClientTest {
       HTTPResponseBuilder hrb = new HTTPResponseBuilder().setResponseHeader(new HTTPResponseHeader(HTTPResponseCode.SwitchingProtocols, HTTPConstants.HTTP_VERSION_1_1));
       hrb.setHeader(HTTPConstants.HTTP_KEY_WEBSOCKET_ACCEPT, "BADKEY");
       hrb.setHeader(HTTPConstants.HTTP_KEY_CONTENT_LENGTH, null);
-      client.write(hrb.build().getByteBuffer());
+      client.write(hrb.build().getMergedByteBuffers());
     }
   }
 
@@ -335,7 +335,7 @@ public class WebSocketClientTest {
           HTTPResponseBuilder hrb = new HTTPResponseBuilder().setResponseHeader(new HTTPResponseHeader(HTTPResponseCode.SwitchingProtocols, HTTPConstants.HTTP_VERSION_1_1));
           hrb.setHeader(HTTPConstants.HTTP_KEY_WEBSOCKET_ACCEPT, respKey);
           hrb.setHeader(HTTPConstants.HTTP_KEY_CONTENT_LENGTH, null);
-          client.write(hrb.build().getByteBuffer());
+          client.write(hrb.build().getMergedByteBuffers());
           if(mbb.remaining() > 0) {
             client.write(mbb.pullBuffer(mbb.remaining()));
           }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.threadly
-version = 0.24
-threadlyVersion = 5.37
+version = 0.25-SNAPSHOT
+threadlyVersion = 5.38
 litesocketsVersion = 4.10
 org.gradle.parallel=false
 junitVersion = 4.12

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestBuilder.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestBuilder.java
@@ -316,7 +316,6 @@ public class HTTPRequestBuilder {
     return this;
   }
 
-
   /**
    * Replaces all the {@link HTTPHeaders} for this HTTPRequestBuilder with the ones provided.
    * 
@@ -330,7 +329,6 @@ public class HTTPRequestBuilder {
     }
     return this;
   }
-
 
   /**
    * Sets the {@link HTTPRequestMethod} for this request.  This uses the standard http request methods enum.

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestProcessor.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestProcessor.java
@@ -229,6 +229,7 @@ public class HTTPRequestProcessor {
             reset();
             return false;
           } else {
+            // TODO - don't allocate a full chunk, chunks may be large
             chunkedBB = ByteBuffer.allocate((int)bodySize); // we can int cast safely due to int parse above
             return true;
           }
@@ -263,7 +264,6 @@ public class HTTPRequestProcessor {
       hrc.bodyData(bb.duplicate());
     }
   }
-
 
   /**
    * Forces a reset on the HTTPProcessor.  This will call finish on any set callbacks if a request has started.

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/response/HTTPResponse.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/response/HTTPResponse.java
@@ -4,11 +4,11 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
+import org.threadly.litesockets.buffers.SimpleMergedByteBuffers;
 import org.threadly.litesockets.protocols.http.shared.HTTPConstants;
 import org.threadly.litesockets.protocols.http.shared.HTTPHeaders;
 import org.threadly.litesockets.protocols.http.shared.HTTPParsingException;
 import org.threadly.litesockets.protocols.http.shared.HTTPResponseCode;
-
 
 /**
  *  An Immutable HTTPResponse object.  This contains all information from an HTTP Response.
@@ -71,8 +71,11 @@ public class HTTPResponse {
   /**
    * Gets this {@link HTTPResponse} as a {@link ByteBuffer}.
    * 
+   * @deprecated Please use {@link #getMergedByteBuffers()} to avoid copying the data
+   * 
    * @return a {@link ByteBuffer} of this {@link HTTPResponse}.
    */
+  @Deprecated
   public ByteBuffer getByteBuffer() {
     ByteBuffer combined = ByteBuffer.allocate(headers.toString().length() + rHeader.length() + 
         HTTPConstants.HTTP_NEWLINE_DELIMINATOR.length() + 
@@ -83,6 +86,19 @@ public class HTTPResponse {
     combined.put(HTTPConstants.HTTP_NEWLINE_DELIMINATOR.getBytes());
     combined.flip();
     return combined;
+  }
+  
+  /**
+   * Gets this {@link HTTPResponse} as a {@link ByteBuffer}.
+   * 
+   * @return a {@link ByteBuffer} of this {@link HTTPResponse}.
+   */
+  public SimpleMergedByteBuffers getMergedByteBuffers() {
+    return new SimpleMergedByteBuffers(true, 
+                                       rHeader.getByteBuffer(), 
+                                       HTTPConstants.HTTP_NEWLINE_DELIMINATOR_BUFFER.duplicate(), 
+                                       ByteBuffer.wrap(headers.toString().getBytes()), 
+                                       HTTPConstants.HTTP_NEWLINE_DELIMINATOR_BUFFER.duplicate());
   }
   
   @Override

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/shared/HTTPConstants.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/shared/HTTPConstants.java
@@ -1,5 +1,6 @@
 package org.threadly.litesockets.protocols.http.shared;
 
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +23,8 @@ public class HTTPConstants {
   
   public static final String HTTP_DOUBLE_NEWLINE_DELIMINATOR = "\r\n\r\n";
   public static final String HTTP_NEWLINE_DELIMINATOR = "\r\n";
+  public static final ByteBuffer HTTP_NEWLINE_DELIMINATOR_BUFFER = 
+      ByteBuffer.wrap(HTTP_NEWLINE_DELIMINATOR.getBytes()).asReadOnlyBuffer();
   public static final String HTTP_HEADER_VALUE_DELIMINATOR = ":";
   public static final String SPACE = " ";
   

--- a/protocol/src/test/java/org/threadly/litesockets/protocols/http/ResponseTests.java
+++ b/protocol/src/test/java/org/threadly/litesockets/protocols/http/ResponseTests.java
@@ -84,7 +84,7 @@ public class ResponseTests {
         
       }});
     HTTPResponse hr = new HTTPResponseBuilder().build();
-    hrp.processData(hr.getByteBuffer());
+    hrp.processData(hr.getMergedByteBuffers());
     assertEquals(hr, header.get(5,TimeUnit.SECONDS));
     assertTrue(finished.get(5,TimeUnit.SECONDS));
   }

--- a/server/src/main/java/org/threadly/litesockets/server/http/HTTPServer.java
+++ b/server/src/main/java/org/threadly/litesockets/server/http/HTTPServer.java
@@ -274,7 +274,7 @@ public class HTTPServer extends AbstractService {
           closeOnDone = true;
         }
         responseSent = true;
-        return client.write(hr.getByteBuffer());
+        return client.write(hr.getMergedByteBuffers());
       } else if (responseSent) {
         throw new IllegalStateException("HTTPResponse already sent!");
       } else {


### PR DESCRIPTION
Broken down by commit:
Commit 1: Performance improvements by reducing heap consumption and data copies

Commit 2: Fix bug in HTTPClient where the concurrent requests / connections can exceed the defined limit

Commit 3: An expansion to the HTTPRequestBuilder so that async streamed body content can be provided.

`HTTPStreamClient` is a good implementation, however it does not have connection pooling, or timeout capabilities.  I think it's way more usable if we can instead bring these concepts into the normal `HTTPClient` so that these large requests can be used among other simpler requests with a common connection pool

@lwahlmeier I am unsure if you think this is a clean enough implementation to warrant deprecating `HTTPStreamClient`

I would like to figure out some solution for streaming in incoming data from the response, but that will be for a future PR.