### PR TITLE
More streaming improvements (primarily consuming responses)

### DIFF
--- a/client/src/main/java/org/threadly/litesockets/client/http/HTTPClient.java
+++ b/client/src/main/java/org/threadly/litesockets/client/http/HTTPClient.java
@@ -15,7 +15,6 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -83,7 +82,7 @@ public class HTTPClient extends AbstractService {
 
   /**
    * <p>This is the default constructor it will create its own {@link SingleThreadScheduler} to use as a threadpool, as
-   * well as using the default {@value DEFAULT_CONCURRENT} and {@value MAX_HTTP_RESPONSE}.  This means we will do at most
+   * well as using the default {@value DEFAULT_CONCURRENT} and no queue limit.  This means we will do at most
    * 2 HTTPRequests at the same time, and those responses can be up to 1mb in size.</p>
    * 
    */

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/response/HTTPResponseProcessor.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/response/HTTPResponseProcessor.java
@@ -106,10 +106,9 @@ public class HTTPResponseProcessor {
         }
         response = new HTTPResponse(hrh, hh);
         listeners.call().headersFinished(response);
-        if(!response.getHeaders().isChunked() && 
-            response.getResponseCode() != HTTPResponseCode.SwitchingProtocols && 
+        if(response.getResponseCode() != HTTPResponseCode.SwitchingProtocols && 
             (headRequest || response.getResponseCode() == HTTPResponseCode.NoContent || 
-             response.getHeaders().getContentLength() == 0)) {
+                (!response.getHeaders().isChunked() && response.getHeaders().getContentLength() == 0))) {
           reset(null);
         }
       } catch(Exception e) {

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/response/HTTPResponseProcessor.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/response/HTTPResponseProcessor.java
@@ -138,8 +138,9 @@ public class HTTPResponseProcessor {
           reset(new HTTPParsingException("Did not complete chunked encoding!"));
         }
       } else {
-        if(response.getHeaders().getContentLength() > 0 && response.getHeaders().getContentLength() != this.currentBodySize) {
-          reset(new HTTPParsingException("Did not get complete body!"));
+        long contentLength = response.getHeaders().getContentLength();
+        if(contentLength > 0 && contentLength != this.currentBodySize) {
+          reset(new HTTPParsingException("Body not completed! (" + currentBodySize + "/" + contentLength + ")"));
         } else {
           reset(null);
         }

--- a/protocol/src/test/java/org/threadly/litesockets/protocols/http/RequestTests.java
+++ b/protocol/src/test/java/org/threadly/litesockets/protocols/http/RequestTests.java
@@ -149,7 +149,7 @@ public class RequestTests {
     assertEquals("/test12334", cb.request.getHTTPRequestHeader().getRequestPath());
     assertEquals(HTTPRequestMethod.GET.toString(), cb.request.getHTTPRequestHeader().getRequestMethod());
     assertEquals("1", cb.request.getHTTPRequestHeader().getRequestQueryValue("query"));
-    hrp.processData(DATA_BA);
+    hrp.processData(ByteBuffer.wrap(DATA_BA));
     assertTrue(cb.finished);
     assertEquals(1, cb.bbs.size());
     assertEquals(DATA, bbToString(cb.bbs.get(0).duplicate()));
@@ -216,7 +216,7 @@ public class RequestTests {
     hrp.addHTTPRequestCallback(cb);
     HTTPRequest hr = hrb.buildHTTPRequest();
     hrp.processData(hr.getMergedByteBuffers());
-    hrp.processData("TRE\r\n".getBytes());
+    hrp.processData(ByteBuffer.wrap("TRE\r\n".getBytes()));
     assertTrue(cb.error != null);
     assertTrue(cb.error instanceof HTTPParsingException);
   }
@@ -233,7 +233,7 @@ public class RequestTests {
     for(int i = 0; i<ba.length; i++) {
       byte[] nba = new byte[1];
       nba[0] = ba[i];
-      hrp.processData(nba);
+      hrp.processData(ByteBuffer.wrap(nba));
     }
     hrp.processData(HTTPUtils.wrapInChunk(ByteBuffer.allocate(0)));
     assertTrue(cb.finished);
@@ -255,10 +255,10 @@ public class RequestTests {
     assertEquals("/test12334", cb.request.getHTTPRequestHeader().getRequestPath());
     assertEquals(HTTPRequestMethod.GET.toString(), cb.request.getHTTPRequestHeader().getRequestMethod());
     assertEquals("1", cb.request.getHTTPRequestHeader().getRequestQueryValue("query"));
-    hrp.processData(wrapInChunk(DATA_BA));
+    hrp.processData(ByteBuffer.wrap(wrapInChunk(DATA_BA)));
     assertEquals(1, cb.bbs.size());
     assertEquals(DATA, bbToString(cb.bbs.get(0).duplicate()));
-    hrp.processData(wrapInChunk(DATA_BA));
+    hrp.processData(ByteBuffer.wrap(wrapInChunk(DATA_BA)));
     assertFalse(cb.finished);
     assertEquals(2, cb.bbs.size());
     assertEquals(DATA, bbToString(cb.bbs.get(1).duplicate()));


### PR DESCRIPTION
This PR includes some cleanup from the previous PR as well as further improvements around consuming large responses.  This PR does include some API breaking changes as described in https://github.com/threadly/litesockets-http/commit/d3b0a56e2618c280e2308614c5f4be047cab2588

Highlights (not in commit order):
* Javadocs from previous PR added https://github.com/threadly/litesockets-http/commit/838cd67bd98aeca9f380a817d92ee673abe261a9
* Unit tests from previous PR cleaned up / enabled https://github.com/threadly/litesockets-http/commit/3dc5e5f2201cc9389f1da89094fb030f254ca27f
* TODO note around large chunk allocations fixed https://github.com/threadly/litesockets-http/commit/b6bea4d08f1b9948d08d1ee4b1d2f75e077c56aa
* Allow per-request override of response body sizes and how they are handled: https://github.com/threadly/litesockets-http/commit/d3b0a56e2618c280e2308614c5f4be047cab2588

The last commit is what introduces most of the API changes.  As described in the message, max response size can't be set on the HTTPClient, and instead must be set per-request, since each request defines how the response body is handled.  Responses by default will be buffered into heap and behave the same, however this logic can be overridden to provide a streamed response if desired.

Since this is API breaking already I made a few other small API changes, feel fee to comment on them individually if you have any concerns.