### PR TITLE
Don't enforce a maximum request timeout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = org.threadly
-version = 0.26-SNAPSHOT
+version = 0.26
 threadlyVersion = 5.39
 litesocketsVersion = 4.10
 org.gradle.parallel=false

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequest.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequest.java
@@ -14,7 +14,6 @@ import org.threadly.litesockets.protocols.http.shared.HTTPParsingException;
 public class HTTPRequest {
   public static final int DEFAULT_TIMEOUT_MS = 20000;
   public static final int MIN_TIMEOUT_MS = 500;
-  public static final int MAX_TIMEOUT_MS = 300000;
   
   private final HTTPRequestHeader request;
   private final HTTPHeaders headers;

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestBuilder.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestBuilder.java
@@ -445,8 +445,12 @@ public class HTTPRequestBuilder {
     return this;
   }
 
-  public HTTPRequestBuilder setTimeout(long size, TimeUnit unit) {
-    this.timeoutMS = (int)Math.min(Math.max(unit.toMillis(size),HTTPRequest.MIN_TIMEOUT_MS), HTTPRequest.MAX_TIMEOUT_MS);
+  public HTTPRequestBuilder setTimeout(long value, TimeUnit unit) {
+    if (value <= 0) {
+      this.timeoutMS = -1;
+    } else {
+      this.timeoutMS = (int)Math.max(unit.toMillis(value), HTTPRequest.MIN_TIMEOUT_MS);
+    }
     return this;
   }
 


### PR DESCRIPTION
Since requests may be slow (particularly if chunked and large), this allows you to configure the request / client to accept very large timeouts.
You can also disable the timeout by providing a 0 or negative value.