### PR TITLE
Add logging around early chunked encoding close

### DIFF
--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/response/HTTPResponseProcessor.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/response/HTTPResponseProcessor.java
@@ -134,7 +134,8 @@ public class HTTPResponseProcessor {
         if (this.nextChunkSize == -1 || this.nextChunkSize == 0) {
           reset(null);
         } else {
-          reset(new HTTPParsingException("Did not complete chunked encoding!"));
+          reset(new HTTPParsingException("Did not complete chunked encoding! " + 
+                                            this.buffers.remaining() + " / " + nextChunkSize));
         }
       } else {
         long contentLength = response.getHeaders().getContentLength();


### PR DESCRIPTION
I thought there was an issue with a connection close with no final chunk, but the parser seems to already be tolerant of this state (per the new unit test added).  So instead I added the buffer values to the error message to try and better understand my issue.

@lwahlmeier any thoughts?