### PR TITLE
Avoid Enum.values() creating an array for parsing the values

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.threadly
 version = 0.27-SNAPSHOT
-threadlyVersion = 5.40
+threadlyVersion = 5.41
 litesocketsVersion = 4.11
 org.gradle.parallel=false
 junitVersion = 4.12

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/shared/HTTPResponseCode.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/shared/HTTPResponseCode.java
@@ -69,8 +69,11 @@ public enum HTTPResponseCode {
   NetworkAuthenticationRequired(511, "Network Authentication Required") /*(RFC 6585)*/, 
   OptionNotSupported(551, "Option not supported") /*(RTSP)*/;
   
-  private int val;
-  private String text;
+  private static final HTTPResponseCode[] VALUES = HTTPResponseCode.values(); // avoid copies
+  
+  private final int val;
+  private final String text;
+  
   private HTTPResponseCode(int val, String text) {
     this.val = val;
     this.text = text;
@@ -97,7 +100,7 @@ public enum HTTPResponseCode {
    * @throws IllegalArgumentException thrown if no code is associated with the provided value
    */
   public static HTTPResponseCode findResponseCode(int val) {
-    for(HTTPResponseCode hrc: HTTPResponseCode.values()) { 
+    for(HTTPResponseCode hrc: VALUES) { 
       if(hrc.getId() == val) {
         return hrc;
       }

--- a/protocol/src/main/java/org/threadly/litesockets/protocols/websocket/WSOPCode.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/websocket/WSOPCode.java
@@ -7,6 +7,8 @@ public enum WSOPCode {
   Continuation((byte)0), Text((byte)1), Binary((byte)2),
   Close((byte)8), Ping((byte)9), Pong((byte)10); 
   
+  private static final WSOPCode[] VALUES = WSOPCode.values(); // avoid copies
+  
   private final byte value;
   
   private WSOPCode(byte value) {
@@ -29,7 +31,7 @@ public enum WSOPCode {
    * @return Matching opcode or {@code null} if none was found
    */
   public static WSOPCode fromByte(byte b) {
-    for(WSOPCode oc: WSOPCode.values()) {
+    for(WSOPCode oc: VALUES) {
       if(oc.getValue() == b) {
         return oc;
       }


### PR DESCRIPTION
Since arrays can't be immutable the JVM will always construct and return a new enum array.
This change is a GC / performance improvement to avoid those creations and collections by using a private static array.