### PR TITLE
HTTPRequestProcessor: Reduced buffer allocations for chunked encoding

### DIFF
--- a/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestProcessor.java
+++ b/protocol/src/main/java/org/threadly/litesockets/protocols/http/request/HTTPRequestProcessor.java
@@ -265,7 +265,10 @@ public class HTTPRequestProcessor {
         sendDuplicateBBtoListeners(chunkedBB);
         int remaining = Math.min(((int)bodySize) - currentBodySize, MAX_CHUNK_SIZE);
         if (remaining > 0) {
-          chunkedBB = ByteBuffer.allocate(remaining);
+          chunkedBB.clear();
+          if (remaining < chunkedBB.capacity()) {
+            chunkedBB.limit(remaining);
+          } // it should not be possible for remaining to be larger than the buffer size
         } else {
           chunkedBB = null;
         }
@@ -306,7 +309,10 @@ public class HTTPRequestProcessor {
     this.request = null;
     this.currentBodySize = 0;
     this.bodySize = 0;
-    this.isChunked = false;
+    if (isChunked) {
+      isChunked = false;
+      chunkedBB = null;
+    }
   }
 
   /**


### PR DESCRIPTION
A minor improvement to reduce the allocation / throw away of buffers when the chunk sizes are beyond our maximum buffer size.  This also has a fix where the chunkedBB may not be cleared on a `reset()`.