### PR TITLE
HTTPClient: NullPointerException fix in consuming post bodies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.threadly
-version = 0.27
-threadlyVersion = 5.41
+version = 0.28-SNAPSHOT
+threadlyVersion = 5.42
 litesocketsVersion = 4.13
 org.gradle.parallel=false
 junitVersion = 4.12


### PR DESCRIPTION
The body provider may provide the body chunks off the client thread.  This means that the client may transition to null if the SettableListenableFuture is completed in error.
If this happens a NullPointerException would have been thrown on line 402 (old code, 411 new code) when the client is attempted to be used for the next write.